### PR TITLE
feat(calculator): add modulo function closes #3

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -19,6 +19,11 @@ pub mod calculator {
     pub fn divide(a: i32, b: i32) -> Option<i32> {
         if b == 0 { None } else { Some(a / b) }
     }
+
+    /// Compute the modulo of two numbers. Returns None if divisor is zero.
+    pub fn modulo(a: i32, b: i32) -> Option<i32> {
+        if b == 0 { None } else { Some(a % b) }
+    }
 }
 
 #[cfg(test)]
@@ -48,5 +53,15 @@ mod tests {
     #[test]
     fn test_divide_by_zero() {
         assert_eq!(divide(10, 0), None);
+    }
+
+    #[test]
+    fn test_modulo() {
+        assert_eq!(modulo(10, 3), Some(1));
+    }
+
+    #[test]
+    fn test_modulo_by_zero() {
+        assert_eq!(modulo(10, 0), None);
     }
 }


### PR DESCRIPTION
## Summary
- Add `modulo(a: i32, b: i32) -> Option<i32>` function to the `calculator` module
- Returns `None` when divisor is zero, following the same pattern as the existing `divide` function
- Includes tests for the normal case and the zero divisor guard

## Files changed
- `rust/src/lib.rs` - Added `modulo` function and two tests in the existing `#[cfg(test)]` block

## Test plan
- `cargo test --lib --all-features` passes
- Normal case: `modulo(10, 3)` returns `Some(1)`
- Zero divisor case: `modulo(10, 0)` returns `None`

Closes #3