### PR TITLE
fix(calculator): add remainder function and test_remainder test

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -19,6 +19,11 @@ pub mod calculator {
     pub fn divide(a: i32, b: i32) -> Option<i32> {
         if b == 0 { None } else { Some(a / b) }
     }
+
+    /// Return the remainder of dividing two numbers.
+    pub fn remainder(a: i32, b: i32) -> i32 {
+        a % b
+    }
 }
 
 #[cfg(test)]
@@ -48,5 +53,10 @@ mod tests {
     #[test]
     fn test_divide_by_zero() {
         assert_eq!(divide(10, 0), None);
+    }
+
+    #[test]
+    fn test_remainder() {
+        assert_eq!(remainder(10, 3), 1);
     }
 }


### PR DESCRIPTION
## Summary
- Added `remainder(a: i32, b: i32) -> i32` function to the `calculator` module using the `%` operator
- Added `test_remainder` unit test asserting correct behavior (`remainder(10, 3) == 1`)
- All 6 tests pass and clippy is clean

## Files changed
- `rust/src/lib.rs` - added `remainder` function and `test_remainder` test to the calculator module

## Test plan
- [ ] `cargo test` passes (all 6 tests including `test_remainder`)
- [ ] `cargo clippy` reports no warnings
- [ ] `cargo fmt --check` passes

Closes #2