### PR TITLE
fix(calculator): add Sqrt with error on negative input closes #5

### DIFF
--- a/go/calculator.go
+++ b/go/calculator.go
@@ -1,9 +1,13 @@
 // Package calculator provides simple arithmetic operations for testing forza workflows.
 package calculator
 
-import "errors"
+import (
+	"errors"
+	"math"
+)
 
 var ErrDivideByZero = errors.New("division by zero")
+var ErrNegativeInput = errors.New("negative input")
 
 // Add returns the sum of two integers.
 func Add(a, b int) int {
@@ -26,4 +30,12 @@ func Divide(a, b int) (int, error) {
 		return 0, ErrDivideByZero
 	}
 	return a / b, nil
+}
+
+// Sqrt returns the integer square root of n. Returns an error if n is negative.
+func Sqrt(n int) (int, error) {
+	if n < 0 {
+		return 0, ErrNegativeInput
+	}
+	return int(math.Sqrt(float64(n))), nil
 }

--- a/go/calculator_test.go
+++ b/go/calculator_test.go
@@ -33,3 +33,17 @@ func TestDivideByZero(t *testing.T) {
 		t.Error("Divide(10, 0) should return error")
 	}
 }
+
+func TestSqrt(t *testing.T) {
+	got, err := Sqrt(9)
+	if err != nil || got != 3 {
+		t.Errorf("Sqrt(9) = %d, %v, want 3, nil", got, err)
+	}
+}
+
+func TestSqrtNegative(t *testing.T) {
+	_, err := Sqrt(-1)
+	if err == nil {
+		t.Error("Sqrt(-1) should return error")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a `Sqrt` function to `go/calculator.go` that computes the integer square root
- Returns `(int, error)` with a sentinel `ErrNegativeInput` error for negative inputs, preventing panics
- Follows the existing pattern established by `Divide`/`ErrDivideByZero`

## Files changed
- `go/calculator.go` - Added `ErrNegativeInput` sentinel and `Sqrt` function using `math.Sqrt`
- `go/calculator_test.go` - Added tests for `Sqrt` covering success path and negative-input error path

## Test plan
- [x] `Sqrt(9)` returns `3, nil`
- [x] `Sqrt(-1)` returns `0, ErrNegativeInput`
- [x] `go test ./...` passes

Closes #5