### PR TITLE
feat(calculator): add abs function to Rust and Go calculators closes #14

### DIFF
--- a/go/calculator.go
+++ b/go/calculator.go
@@ -27,3 +27,11 @@ func Divide(a, b int) (int, error) {
 	}
 	return a / b, nil
 }
+
+// Abs returns the absolute value of an integer.
+func Abs(a int) int {
+	if a < 0 {
+		return -a
+	}
+	return a
+}

--- a/go/calculator_test.go
+++ b/go/calculator_test.go
@@ -33,3 +33,12 @@ func TestDivideByZero(t *testing.T) {
 		t.Error("Divide(10, 0) should return error")
 	}
 }
+
+func TestAbs(t *testing.T) {
+	if got := Abs(-5); got != 5 {
+		t.Errorf("Abs(-5) = %d, want 5", got)
+	}
+	if got := Abs(5); got != 5 {
+		t.Errorf("Abs(5) = %d, want 5", got)
+	}
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -19,6 +19,11 @@ pub mod calculator {
     pub fn divide(a: i32, b: i32) -> Option<i32> {
         if b == 0 { None } else { Some(a / b) }
     }
+
+    /// Return the absolute value of a number.
+    pub fn abs(a: i32) -> i32 {
+        if a < 0 { -a } else { a }
+    }
 }
 
 #[cfg(test)]
@@ -48,5 +53,11 @@ mod tests {
     #[test]
     fn test_divide_by_zero() {
         assert_eq!(divide(10, 0), None);
+    }
+
+    #[test]
+    fn test_abs() {
+        assert_eq!(abs(-5), 5);
+        assert_eq!(abs(5), 5);
     }
 }


### PR DESCRIPTION
## Summary
- Add `abs` function to Rust calculator (`rust/src/lib.rs`) with doc comment and unit test
- Add `Abs` function to Go calculator (`go/calculator.go`) with doc comment and unit test
- Both implementations use simple conditional logic consistent with existing code style
- Resolves issue #14 requesting absolute value support in both languages

## Files changed
- `rust/src/lib.rs` — added `abs(a: i32) -> i32` function and `test_abs` unit test
- `go/calculator.go` — added `Abs(a int) int` function with doc comment
- `go/calculator_test.go` — added `TestAbs` test covering negative and positive inputs

## Test plan
- [ ] `cargo test` passes in `rust/` directory
- [ ] `go test ./...` passes in `go/` directory
- [ ] `cargo clippy` reports no warnings
- [ ] Both `abs(-5) == 5` and `abs(5) == 5` asserted in each language

Closes #14