### PR TITLE
feat(calculator): add is_positive function closes #31

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -28,6 +28,11 @@ pub mod calculator {
             Ok(a / b)
         }
     }
+
+    /// Returns true if n is positive.
+    pub fn is_positive(n: i32) -> bool {
+        n > 0
+    }
 }
 
 #[cfg(test)]
@@ -57,6 +62,13 @@ mod tests {
     #[test]
     fn test_divide_by_zero() {
         assert_eq!(divide(10, 0), Err("division by zero"));
+    }
+
+    #[test]
+    fn test_is_positive() {
+        assert!(is_positive(5));
+        assert!(!is_positive(0));
+        assert!(!is_positive(-3));
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `is_positive(n: i32) -> bool` function to the `calculator` module in `rust/src/lib.rs`
- Implementation returns `n > 0`, correctly handling positive integers, zero, and negatives
- Doc comment added consistent with existing function documentation style
- Tests cover all boundary conditions: positive number, zero, and negative number

## Files changed
- `rust/src/lib.rs` - Added `is_positive` function and corresponding unit tests

## Test plan
- `cargo test` passes with new tests for `is_positive(5)` (true), `is_positive(0)` (false), `is_positive(-3)` (false)
- `cargo clippy` passes with no warnings
- `cargo fmt` applied

Closes #31