### PR TITLE
feat(calculator): add is_even function closes #30

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -28,6 +28,11 @@ pub mod calculator {
     pub fn is_positive(n: i32) -> bool {
         n > 0
     }
+
+    /// Returns true if n is even, false if odd.
+    pub fn is_even(n: i32) -> bool {
+        n % 2 == 0
+    }
 }
 
 #[cfg(test)]
@@ -64,6 +69,12 @@ mod tests {
         assert!(is_positive(5));
         assert!(!is_positive(0));
         assert!(!is_positive(-3));
+    }
+
+    #[test]
+    fn test_is_even() {
+        assert!(is_even(4));
+        assert!(!is_even(3));
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds `is_even(n: i32) -> bool` to the `calculator` module in `rust/src/lib.rs`
- Implementation uses `n % 2 == 0`, which is correct for all `i32` inputs including negative numbers and zero
- Includes a doc comment following existing conventions
- Adds unit tests covering even and odd cases

## Files changed
- `rust/src/lib.rs` - Added `is_even` function with doc comment and unit tests

## Test plan
- [ ] `cargo test --lib --all-features` passes
- [ ] Unit tests verify `is_even(2)` returns `true` and `is_even(3)` returns `false`
- [ ] `cargo fmt --all -- --check` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes

Closes #30