### PR TITLE
fix: install claude code directly

### DIFF
--- a/.github/workflows/forza.yml
+++ b/.github/workflows/forza.yml
@@ -29,7 +29,8 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - uses: anthropics/setup-claude-code@v1
+      - name: Install Claude Code
+        run: curl -fsSL https://claude.ai/install.sh | bash
 
       - uses: joshrotenberg/forza/action@feat/github-action
         with:


### PR DESCRIPTION
Replace nonexistent anthropics/setup-claude-code with direct curl install.