### PR TITLE
fix: use --workflow bug (quick not in v0.5.0 yet)

### DIFF
--- a/.github/workflows/test-scenarios.yml
+++ b/.github/workflows/test-scenarios.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Run forza
         run: |
           forza issue ${{ steps.issue.outputs.number }} \
-            --workflow quick \
+            --workflow bug \
             --config forza.toml
 
       - name: Verify results


### PR DESCRIPTION
The v0.5.0 release was built before the workflow rationalization PR. Use `bug` until the next release includes `quick`.