### PR TITLE
fix: use --workflow quick and --base-branch for scenarios

### DIFF
--- a/.github/workflows/test-scenarios.yml
+++ b/.github/workflows/test-scenarios.yml
@@ -63,14 +63,6 @@ jobs:
             | tar xJ --strip-components=1 -C /usr/local/bin
           forza --version
 
-      - name: Create test branch from scenario tag
-        id: setup
-        run: |
-          BRANCH="test/bug-rust-$(date +%s)"
-          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
-          git checkout -b "$BRANCH" "$SCENARIO_TAG"
-          git push origin "$BRANCH"
-
       - name: Create test issue
         id: issue
         run: |
@@ -85,7 +77,8 @@ jobs:
       - name: Run forza
         run: |
           forza issue ${{ steps.issue.outputs.number }} \
-            --workflow bug \
+            --workflow quick \
+            --base-branch "$SCENARIO_TAG" \
             --config forza.toml
 
       - name: Verify results
@@ -129,6 +122,3 @@ jobs:
           for pr in $(gh pr list --repo "$REPO" --json number,headRefName --jq '.[] | select(.headRefName | startswith("automation/")) | .number' 2>/dev/null); do
             gh pr close "$pr" --repo "$REPO" --delete-branch 2>/dev/null || true
           done
-
-          # Delete test branch
-          git push origin --delete "${{ steps.setup.outputs.branch }}" 2>/dev/null || true


### PR DESCRIPTION
Uses v0.5.2 features: `--workflow quick` and `--base-branch scenario/bug-rust-v1` so forza works on the broken code from the tag, not clean main.